### PR TITLE
Fix to-the-top button

### DIFF
--- a/client/src/components/Button/GoToTopButton.jsx
+++ b/client/src/components/Button/GoToTopButton.jsx
@@ -17,10 +17,8 @@ const GoToTopButton = () => {
 
   const handleScroll = () => {
     const scrollY = window.scrollY;
-    const stopPosition = 960;
-
-    setShowButton(scrollY > 5);
-
+    const stopPosition = Math.max(document.body.scrollHeight, document.body.offsetHeight, document.body.clientHeight) - window.innerHeight - 70;
+    setShowButton(scrollY > 10);
     if (scrollY > stopPosition) {
       setStopPosition(true);
     } else {

--- a/client/src/components/Courses/Courses.jsx
+++ b/client/src/components/Courses/Courses.jsx
@@ -66,7 +66,6 @@ const Course = ({
         >
           Add to Playlist
         </Button>
-        <GoToTopButton />
       </Stack>
     </VStack>
   );
@@ -135,6 +134,7 @@ const Courses = () => {
           addToPlayListHandler={addToPlayListHandler}
         />
       </Stack>
+      <GoToTopButton />
     </Container>
   );
 };


### PR DESCRIPTION
Related Issue #65 - [Bug]: Problem in Top button

The to the top button was in the middle of the screen that is now moved to the bottom right corner. The image in the course page is not displayed because the url from which it is fetched is not sending the image.

![image](https://github.com/anand-harsh/Edumi/assets/80145855/4574fc2f-28e5-4ad4-abe4-b6d8c9e9a29b)


After:

https://github.com/anand-harsh/Edumi/assets/80145855/aee2c5ab-66ea-4ddb-b1fd-af1e17d4c5a7


