### PR TITLE
Adding Backend API for Refresh Token

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -341,13 +341,11 @@ export const updateDetails = catchAsyncError(async (req, res, next) => {
       );
       const UserData = await User.findById(req.user._id);
       isUpdated &&
-        res
-          .status(200)
-          .json({
-            success: true,
-            message: "Information Updated Successfully",
-            User: UserData,
-          });
+        res.status(200).json({
+          success: true,
+          message: "Information Updated Successfully",
+          User: UserData,
+        });
     } else {
       res
         .status(502)
@@ -355,5 +353,33 @@ export const updateDetails = catchAsyncError(async (req, res, next) => {
     }
   } catch (error) {
     console.log(error);
+  }
+});
+
+export const refreshAccessToken = catchAsyncError(async (req, res) => {
+  const { id } = req.params;
+  const { refreshToken } = req.cookies;
+
+  try {
+    if (!id || !refreshToken) {
+      throw new ErrorHandler("ID or Refresh Token Missing", 402);
+    }
+
+    const isUserExist = await User.findById(id);
+    if (!isUserExist) {
+      throw new ErrorHandler(`User Not Exist With Provided Id : ${id}`, 402);
+    }
+
+    const isCorrectRefreshToken = isUserExist.refreshToken === refreshToken;
+    if (!isCorrectRefreshToken) {
+      throw new ErrorHandler("Invalid or Expired Refresh Token", 402);
+    }
+
+    sendToken(res, isUserExist, "Access Token Refreshed", 202);
+  } catch (error) {
+    console.log(error); // Log the error for debugging purposes
+    res
+      .status(error.statusCode || 502)
+      .json({ success: false, message: error.message });
   }
 });

--- a/models/User.js
+++ b/models/User.js
@@ -39,6 +39,10 @@ const schema = new mongoose.Schema({
     //   required: true,
     // },
   },
+  refreshToken: {
+    type: String,
+    default: "",
+  },
   playlist: [
     {
       course: {
@@ -65,6 +69,14 @@ schema.methods.getJWTToken = function () {
   return jwt.sign({ _id: this._id }, process.env.JWT_SECRET, {
     expiresIn: "15d",
   });
+};
+schema.methods.getRefreshToken = function () {
+  const refreshToken = jwt.sign({ _id: this._id }, process.env.JWT_SECRET, {
+    expiresIn: "30d",
+  });
+  this.refreshToken = refreshToken;
+  this.save();
+  return refreshToken;
 };
 schema.methods.comparePassword = async function (password) {
   return await bcrypt.compare(password, this.password);

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -17,6 +17,7 @@ import {
   AdminGetAllUsers,
   updateUserRole,
   updateDetails,
+  refreshAccessToken,
 } from "../controllers/userController.js";
 import { isAuthenticated } from "../middlewares/Auth.js";
 import { isAdminAuthenticated } from "../middlewares/adminAuth.js";
@@ -41,5 +42,7 @@ router.route("/getAllUsers").get(isAdminAuthenticated, AdminGetAllUsers);
 router.route("/admin/users/:id").put(isAuthenticated, updateUserRole);
 
 router.route("/user/details/update").put(isAuthenticated, updateDetails);
+
+router.route("/refresh/token/:id").get(refreshAccessToken);
 
 export default router;

--- a/utils/sendToken.js
+++ b/utils/sendToken.js
@@ -1,17 +1,22 @@
 export const sendToken = (res, user, message, statusCode = 200) => {
   try {
     const token = user.getJWTToken();
+    const refreshToken = user.getRefreshToken();
     const options = {
       expires: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000), // 15 days token valid
       httpOnly: true,
       secure: true,
       // sameSite: true,
     };
-    res.status(statusCode).cookie("authToken", token, options).json({
-      success: true,
-      message,
-      user,
-    });
+    res
+      .status(statusCode)
+      .cookie("authToken", token, options)
+      .cookie("refreshToken", refreshToken, options)
+      .json({
+        success: true,
+        message,
+        user,
+      });
   } catch (error) {
     console.log(error);
   }


### PR DESCRIPTION
- [x] *Have you read the [Contributing Guidelines](https://github.com/jessesquires/.github/blob/master/CONTRIBUTING.md)?*

Issue #121 

## Describe your changes
Adding Backend API for to refresh Access Token Using RefreshToken Field in DB While User Attempt to Make `GET` Request on `/refresh/token/:id` then API will Compare Incoming refreshToken And Stored Token Then It Will Send User Data.